### PR TITLE
Sealed trait support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,14 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-csv" % jacksonVersion % Test
 )
 
+// build.properties
+Compile / resourceGenerators += Def.task {
+  val file = (Compile / resourceManaged).value / "com" / "github" / "pjfanning" / "jackson" / "reflect" / "build.properties"
+  val contents = "version=%s\ngroupId=%s\nartifactId=%s\n".format(version.value, organization.value, name.value)
+  IO.write(file, contents)
+  Seq(file)
+}.taskValue
+
 homepage := Some(url("https://github.com/pjfanning/jackson-scala-reflect-extensions"))
 
 licenses := Seq("APL2" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt"))

--- a/src/main/scala/com/github/pjfanning/jackson/reflect/JacksonModule.scala
+++ b/src/main/scala/com/github/pjfanning/jackson/reflect/JacksonModule.scala
@@ -1,0 +1,27 @@
+package com.github.pjfanning.jackson.reflect
+
+import com.fasterxml.jackson.core.Version
+import com.fasterxml.jackson.core.util.VersionUtil
+import com.fasterxml.jackson.module.scala.JacksonModule
+
+import java.util.Properties
+import scala.collection.mutable
+import scala.collection.JavaConverters._
+
+private[reflect] object JacksonModule {
+  private val cls = classOf[JacksonModule]
+  private val buildPropsFilename = cls.getPackage.getName.replace('.','/') + "/build.properties"
+  lazy val buildProps: mutable.Map[String, String] = {
+    val props = new Properties
+    val stream = cls.getClassLoader.getResourceAsStream(buildPropsFilename)
+    if (stream ne null) props.load(stream)
+
+    props.asScala
+  }
+  lazy val version: Version = {
+    val groupId = buildProps("groupId")
+    val artifactId = buildProps("artifactId")
+    val version = buildProps("version")
+    VersionUtil.parseVersion(version, groupId, artifactId)
+  }
+}

--- a/src/main/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospector.scala
+++ b/src/main/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospector.scala
@@ -1,0 +1,28 @@
+package com.github.pjfanning.jackson.reflect
+
+import com.fasterxml.jackson.core.Version
+import com.fasterxml.jackson.databind.introspect.{Annotated, JacksonAnnotationIntrospector}
+import com.fasterxml.jackson.databind.jsontype.NamedType
+import com.fasterxml.jackson.module.scala.util.ClassW
+
+import java.util
+import scala.collection.JavaConverters._
+import scala.reflect.runtime.{universe => ru}
+
+class ScalaReflectAnnotationIntrospector extends JacksonAnnotationIntrospector {
+  override def version(): Version = JacksonModule.version
+
+  override def findSubtypes(a: Annotated): util.List[NamedType] = {
+    if (ClassW(a.getRawType).extendsScalaClass) {
+      val mirror = ru.runtimeMirror(Thread.currentThread().getContextClassLoader)
+      val moduleSymbol = mirror.moduleSymbol(a.getRawType)
+      moduleSymbol.typeSignature.typeSymbol.asClass.knownDirectSubclasses
+        .map(_.asClass.getClass)
+        .map(new NamedType(_))
+        .toSeq
+        .asJava
+    } else {
+      None.orNull
+    }
+  }
+}

--- a/src/main/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospector.scala
+++ b/src/main/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospector.scala
@@ -40,7 +40,7 @@ class ScalaReflectAnnotationIntrospector extends JacksonAnnotationIntrospector {
       }
     } catch {
       case NonFatal(t) => {
-        logger.warn("Failed to findSubtypes in {}", a.getRawType, t)
+        logger.warn(s"Failed to findSubtypes in ${a.getRawType}", t)
         None.orNull
       }
     }

--- a/src/main/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospector.scala
+++ b/src/main/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospector.scala
@@ -18,9 +18,9 @@ class ScalaReflectAnnotationIntrospector extends JacksonAnnotationIntrospector {
   override def findSubtypes(a: Annotated): util.List[NamedType] = {
     try {
       val mirror = ru.runtimeMirror(Thread.currentThread().getContextClassLoader)
-      val moduleSymbol = mirror.moduleSymbol(a.getRawType)
-      lazy val symbol = companionOrSelf(moduleSymbol)
-      if (moduleSymbol.isJava) {
+      val classSymbol = mirror.classSymbol(a.getRawType)
+      lazy val symbol = companionOrSelf(classSymbol)
+      if (classSymbol.isJava) {
         None.orNull
       } else if (symbol.isClass) {
         val clazzes = symbol.asClass.knownDirectSubclasses
@@ -29,12 +29,6 @@ class ScalaReflectAnnotationIntrospector extends JacksonAnnotationIntrospector {
           .flatMap(s => if (s.isClass) Some(s.asClass) else None)
           .map(c => mirror.runtimeClass(c).getName)
         clazzes.map(cn => new NamedType(Class.forName(cn, true, Thread.currentThread().getContextClassLoader))).asJava
-      } else if (moduleSymbol.isType) {
-        moduleSymbol.asType.asClass.knownDirectSubclasses
-          .map(_.asClass.getClass)
-          .map(new NamedType(_))
-          .toSeq
-          .asJava
       } else {
         None.orNull
       }

--- a/src/main/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospector.scala
+++ b/src/main/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospector.scala
@@ -3,26 +3,51 @@ package com.github.pjfanning.jackson.reflect
 import com.fasterxml.jackson.core.Version
 import com.fasterxml.jackson.databind.introspect.{Annotated, JacksonAnnotationIntrospector}
 import com.fasterxml.jackson.databind.jsontype.NamedType
-import com.fasterxml.jackson.module.scala.util.ClassW
+import org.slf4j.LoggerFactory
 
 import java.util
 import scala.collection.JavaConverters._
 import scala.reflect.runtime.{universe => ru}
+import scala.util.control.NonFatal
 
 class ScalaReflectAnnotationIntrospector extends JacksonAnnotationIntrospector {
+  private val logger = LoggerFactory.getLogger(classOf[ScalaReflectAnnotationIntrospector])
+
   override def version(): Version = JacksonModule.version
 
   override def findSubtypes(a: Annotated): util.List[NamedType] = {
-    if (ClassW(a.getRawType).extendsScalaClass) {
+    try {
       val mirror = ru.runtimeMirror(Thread.currentThread().getContextClassLoader)
       val moduleSymbol = mirror.moduleSymbol(a.getRawType)
-      moduleSymbol.typeSignature.typeSymbol.asClass.knownDirectSubclasses
-        .map(_.asClass.getClass)
-        .map(new NamedType(_))
-        .toSeq
-        .asJava
-    } else {
-      None.orNull
+      lazy val symbol = companionOrSelf(moduleSymbol)
+      if (moduleSymbol.isJava) {
+        None.orNull
+      } else if (symbol.isClass) {
+        val clazzes = symbol.asClass.knownDirectSubclasses
+          .toSeq
+          .sortBy(_.info.toString)
+          .flatMap(s => if (s.isClass) Some(s.asClass) else None)
+          .map(c => mirror.runtimeClass(c).getName)
+        clazzes.map(cn => new NamedType(Class.forName(cn, true, Thread.currentThread().getContextClassLoader))).asJava
+      } else if (moduleSymbol.isType) {
+        moduleSymbol.asType.asClass.knownDirectSubclasses
+          .map(_.asClass.getClass)
+          .map(new NamedType(_))
+          .toSeq
+          .asJava
+      } else {
+        None.orNull
+      }
+    } catch {
+      case NonFatal(t) => {
+        logger.warn("Failed to findSubtypes in {}", a.getRawType, t)
+        None.orNull
+      }
     }
   }
+
+  private def companionOrSelf(sym: ru.Symbol): ru.Symbol = {
+    if (sym.companion == ru.NoSymbol) sym else sym.companion
+  }
+
 }

--- a/src/main/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospectorModule.scala
+++ b/src/main/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospectorModule.scala
@@ -1,0 +1,7 @@
+package com.github.pjfanning.jackson.reflect
+
+trait ScalaReflectAnnotationIntrospectorModule extends JacksonModule {
+  this += { _.appendAnnotationIntrospector(new ScalaReflectAnnotationIntrospector) }
+}
+
+object ScalaReflectAnnotationIntrospectorModule extends ScalaReflectAnnotationIntrospectorModule

--- a/src/test/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospectorModuleTest.scala
+++ b/src/test/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospectorModuleTest.scala
@@ -2,16 +2,17 @@ package com.github.pjfanning.jackson.reflect
 
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.github.pjfanning.jackson.reflect.annotated.Red
+import com.github.pjfanning.jackson.reflect.annotated.{Blue, Car}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class ScalaReflectAnnotationIntrospectorModuleTest extends AnyFlatSpec with Matchers {
-  "ScalaReflectAnnotationIntrospectorModule" should "find sub types for unannotated.Color" ignore {
+  "ScalaReflectAnnotationIntrospectorModule" should "serialize Car with annotated.Color" in {
     val mapper = JsonMapper.builder()
       .addModule(DefaultScalaModule)
-      .addModule(ScalaReflectAnnotationIntrospectorModule)
+      //.addModule(ScalaReflectAnnotationIntrospectorModule)
       .build()
-    mapper.writeValueAsString(Red) shouldEqual "Red"
+    val car = Car("Samand", Blue)
+    mapper.writeValueAsString(car) shouldEqual """{"make":"Samand","color":{"type":"Blue$"}}"""
   }
 }

--- a/src/test/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospectorModuleTest.scala
+++ b/src/test/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospectorModuleTest.scala
@@ -2,7 +2,8 @@ package com.github.pjfanning.jackson.reflect
 
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.github.pjfanning.jackson.reflect.annotated.{Blue, Car}
+import com.fasterxml.jackson.module.scala.deser.ScalaObjectDeserializerModule
+import com.github.pjfanning.jackson.reflect.annotated.{Blue, Car, Red}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -10,9 +11,22 @@ class ScalaReflectAnnotationIntrospectorModuleTest extends AnyFlatSpec with Matc
   "ScalaReflectAnnotationIntrospectorModule" should "serialize Car with annotated.Color" in {
     val mapper = JsonMapper.builder()
       .addModule(DefaultScalaModule)
-      //.addModule(ScalaReflectAnnotationIntrospectorModule)
+      .addModule(ScalaReflectAnnotationIntrospectorModule)
       .build()
     val car = Car("Samand", Blue)
     mapper.writeValueAsString(car) shouldEqual """{"make":"Samand","color":{"type":"Blue$"}}"""
+  }
+
+  it should "deserialize Car with annotated.Color" in {
+    val mapper = JsonMapper.builder()
+      .addModule(DefaultScalaModule)
+      .addModule(ScalaObjectDeserializerModule) //this non-default module prevents duplicate scala objects being created
+      .addModule(ScalaReflectAnnotationIntrospectorModule)
+      .build()
+    val car = Car("Samand", Red)
+    val json = mapper.writeValueAsString(car)
+    val car2 = mapper.readValue(json, classOf[Car])
+    car2.color shouldEqual car.color
+    car2.make shouldEqual car.make
   }
 }

--- a/src/test/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospectorModuleTest.scala
+++ b/src/test/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospectorModuleTest.scala
@@ -1,0 +1,17 @@
+package com.github.pjfanning.jackson.reflect
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.github.pjfanning.jackson.reflect.annotated.Red
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ScalaReflectAnnotationIntrospectorModuleTest extends AnyFlatSpec with Matchers {
+  "ScalaReflectAnnotationIntrospectorModule" should "find sub types for unannotated.Color" ignore {
+    val mapper = JsonMapper.builder()
+      .addModule(DefaultScalaModule)
+      .addModule(ScalaReflectAnnotationIntrospectorModule)
+      .build()
+    mapper.writeValueAsString(Red) shouldEqual "Red"
+  }
+}

--- a/src/test/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospectorTest.scala
+++ b/src/test/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospectorTest.scala
@@ -2,7 +2,6 @@ package com.github.pjfanning.jackson.reflect
 
 import com.fasterxml.jackson.databind.introspect.AnnotatedClassResolver
 import com.fasterxml.jackson.databind.json.JsonMapper
-import com.github.pjfanning.jackson.reflect.annotated.{Blue, Green, Red}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -12,14 +11,27 @@ class ScalaReflectAnnotationIntrospectorTest extends AnyFlatSpec with Matchers {
   "ScalaReflectAnnotationIntrospector" should "find sub types for unannotated.Color" in {
     val introspector = new ScalaReflectAnnotationIntrospector
     val mapper = JsonMapper.builder().build()
+    val colorType = mapper.constructType(classOf[unannotated.Color])
+    val annotatedColor = AnnotatedClassResolver.resolve(
+      mapper.getDeserializationConfig, colorType, mapper.getDeserializationConfig)
+    val subtypes = introspector.findSubtypes(annotatedColor).asScala.toSeq.map(_.getType)
+    subtypes should have size 3
+    subtypes(0) shouldEqual unannotated.Blue.getClass
+    subtypes(1) shouldEqual unannotated.Green.getClass
+    subtypes(2) shouldEqual unannotated.Red.getClass
+  }
+
+  it should "find sub types for annotated.Color" in {
+    val introspector = new ScalaReflectAnnotationIntrospector
+    val mapper = JsonMapper.builder().build()
     val colorType = mapper.constructType(classOf[annotated.Color])
     val annotatedColor = AnnotatedClassResolver.resolve(
       mapper.getDeserializationConfig, colorType, mapper.getDeserializationConfig)
     val subtypes = introspector.findSubtypes(annotatedColor).asScala.toSeq.map(_.getType)
     subtypes should have size 3
-    subtypes(0) shouldEqual Blue.getClass
-    subtypes(1) shouldEqual Green.getClass
-    subtypes(2) shouldEqual Red.getClass
+    subtypes(0) shouldEqual annotated.Blue.getClass
+    subtypes(1) shouldEqual annotated.Green.getClass
+    subtypes(2) shouldEqual annotated.Red.getClass
   }
 
   it should "return version" in {

--- a/src/test/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospectorTest.scala
+++ b/src/test/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospectorTest.scala
@@ -1,0 +1,29 @@
+package com.github.pjfanning.jackson.reflect
+
+import com.fasterxml.jackson.databind.introspect.AnnotatedClassResolver
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.github.pjfanning.jackson.reflect.annotated.{Blue, Green, Red}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.JavaConverters._
+
+class ScalaReflectAnnotationIntrospectorTest extends AnyFlatSpec with Matchers {
+  "ScalaReflectAnnotationIntrospectorTest" should "find sub types for unannotated.Color" in {
+    val introspector = new ScalaReflectAnnotationIntrospector
+    val mapper = JsonMapper.builder().build()
+    val colorType = mapper.constructType(classOf[annotated.Color])
+    val annotatedColor = AnnotatedClassResolver.resolve(
+      mapper.getDeserializationConfig, colorType, mapper.getDeserializationConfig)
+    val subtypes = introspector.findSubtypes(annotatedColor).asScala.toSeq.map(_.getType)
+    subtypes should have size 3
+    subtypes(0) shouldEqual Blue.getClass
+    subtypes(1) shouldEqual Green.getClass
+    subtypes(2) shouldEqual Red.getClass
+  }
+
+  it should "return version" in {
+    val introspector = new ScalaReflectAnnotationIntrospector
+    introspector.version() shouldEqual JacksonModule.version
+  }
+}

--- a/src/test/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospectorTest.scala
+++ b/src/test/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospectorTest.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 import scala.collection.JavaConverters._
 
 class ScalaReflectAnnotationIntrospectorTest extends AnyFlatSpec with Matchers {
-  "ScalaReflectAnnotationIntrospectorTest" should "find sub types for unannotated.Color" in {
+  "ScalaReflectAnnotationIntrospector" should "find sub types for unannotated.Color" in {
     val introspector = new ScalaReflectAnnotationIntrospector
     val mapper = JsonMapper.builder().build()
     val colorType = mapper.constructType(classOf[annotated.Color])

--- a/src/test/scala/com/github/pjfanning/jackson/reflect/annotated/Color.scala
+++ b/src/test/scala/com/github/pjfanning/jackson/reflect/annotated/Color.scala
@@ -1,6 +1,11 @@
 package com.github.pjfanning.jackson.reflect.annotated
 
-sealed abstract class Color
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+
+case class Car(make: String, color: Color)
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+sealed trait Color
 
 case object Red extends Color
 case object Green extends Color

--- a/src/test/scala/com/github/pjfanning/jackson/reflect/annotated/Color.scala
+++ b/src/test/scala/com/github/pjfanning/jackson/reflect/annotated/Color.scala
@@ -1,0 +1,7 @@
+package com.github.pjfanning.jackson.reflect.annotated
+
+sealed abstract class Color
+
+case object Red extends Color
+case object Green extends Color
+case object Blue extends Color

--- a/src/test/scala/com/github/pjfanning/jackson/reflect/unannotated/Color.scala
+++ b/src/test/scala/com/github/pjfanning/jackson/reflect/unannotated/Color.scala
@@ -1,0 +1,9 @@
+package com.github.pjfanning.jackson.reflect.unannotated
+
+case class Car(make: String, color: Color)
+
+sealed trait Color
+
+case object Red extends Color
+case object Green extends Color
+case object Blue extends Color


### PR DESCRIPTION
Using scala-reflect to work out the classes that implement the sealed trait (or abstract class).

```
case class Car(make: String, color: Color)

@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
sealed trait Color

case object Red extends Color
case object Green extends Color
case object Blue extends Color

    val mapper = JsonMapper.builder()
      .addModule(DefaultScalaModule)
      .addModule(ScalaObjectDeserializerModule) //this non-default module prevents duplicate scala objects being created
      .addModule(ScalaReflectAnnotationIntrospectorModule)
      .build()
    val car = Car("Samand", Red)
    val json = mapper.writeValueAsString(car)
    val car2 = mapper.readValue(json, classOf[Car])
    car2.color shouldEqual car.color
    car2.make shouldEqual car.make
```

Unfortunately, you still need to add a JsonTypeInfo to the trait (or abstract class) but you don't need to list out the classes that implement it. ScalaReflectAnnotationIntrospectorModule is the module that enables this.