### PR TITLE
infer json type for scala classes

### DIFF
--- a/src/main/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospector.scala
+++ b/src/main/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospector.scala
@@ -1,8 +1,11 @@
 package com.github.pjfanning.jackson.reflect
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.core.Version
-import com.fasterxml.jackson.databind.introspect.{Annotated, AnnotatedClass, JacksonAnnotationIntrospector}
+import com.fasterxml.jackson.databind.cfg.MapperConfig
+import com.fasterxml.jackson.databind.introspect.{Annotated, AnnotatedClass, AnnotatedMember, JacksonAnnotationIntrospector}
 import com.fasterxml.jackson.databind.jsontype.NamedType
+import com.fasterxml.jackson.module.scala.util.ClassW
 import org.slf4j.LoggerFactory
 
 import java.util
@@ -16,8 +19,52 @@ class ScalaReflectAnnotationIntrospector extends JacksonAnnotationIntrospector {
 
   override def version(): Version = JacksonModule.version
 
+  override def findPolymorphicTypeInfo(config: MapperConfig[_], ann: Annotated): JsonTypeInfo.Value = {
+    ann match {
+      case ac: AnnotatedClass if isScala(ac) =>
+        val t = _findAnnotation(ac, classOf[JsonTypeInfo])
+        if (t == null) {
+          try {
+            val mirror = ru.runtimeMirror(Thread.currentThread().getContextClassLoader)
+            val classSymbol = mirror.classSymbol(ac.getRawType)
+            lazy val symbol = companionOrSelf(classSymbol)
+            if (classSymbol.isJava) {
+              None.orNull
+            } else if (symbol.isClass) {
+              val clz = symbol.asClass
+              // It is possible that other classes might have subclasses
+              // but the risk is that someone wants to serialize the base class
+              // without including type information -- at the moment, users will still
+              // need to add @JsonTypeInfo to the base class
+              val isLikelyBaseClass = clz.isAbstract || clz.isTrait || clz.isSealed
+              if (isLikelyBaseClass && clz.knownDirectSubclasses.nonEmpty) {
+                JsonTypeInfo.Value.construct(JsonTypeInfo.Id.NAME, JsonTypeInfo.As.PROPERTY,
+                  None.orNull, None.orNull, true, None.orNull)
+              } else {
+                None.orNull
+              }
+            } else {
+              None.orNull
+            }
+          } catch {
+            case NonFatal(t) => {
+              logger.warn(s"Failed to findPolymorphicTypeInfo in ${ac.getRawType}: $t")
+              None.orNull
+            }
+            case error: NoClassDefFoundError => {
+              logger.warn(s"Failed to findPolymorphicTypeInfo in ${ac.getRawType}: $error")
+              None.orNull
+            }
+          }
+        } else {
+          JsonTypeInfo.Value.from(t)
+        }
+      case _ => None.orNull
+    }
+  }
+
   override def findSubtypes(ann: Annotated): util.List[NamedType] = ann match {
-    case ac: AnnotatedClass =>
+    case ac: AnnotatedClass if isScala(ac) =>
       try {
         val mirror = ru.runtimeMirror(Thread.currentThread().getContextClassLoader)
         getNamedTypes(mirror.classSymbol(ac.getRawType), mirror)
@@ -54,6 +101,11 @@ class ScalaReflectAnnotationIntrospector extends JacksonAnnotationIntrospector {
 
   private def companionOrSelf(sym: ru.Symbol): ru.Symbol = {
     if (sym.companion == ru.NoSymbol) sym else sym.companion
+  }
+
+  private def isScala(ann: Annotated): Boolean = {
+    val cw = ClassW(ann.getRawType)
+    cw.extendsScalaClass(false) || cw.hasSignature
   }
 
 }

--- a/src/main/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospector.scala
+++ b/src/main/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospector.scala
@@ -14,20 +14,13 @@ import scala.reflect.runtime.universe.ClassSymbol
 import scala.reflect.runtime.{universe => ru}
 import scala.util.control.NonFatal
 
-class ScalaReflectAnnotationIntrospector extends JacksonAnnotationIntrospector {
+class ScalaReflectAnnotationIntrospector(supportInferenceOfJsonTypeInfo: Boolean = true) extends JacksonAnnotationIntrospector {
   private val logger = LoggerFactory.getLogger(classOf[ScalaReflectAnnotationIntrospector])
 
   override def version(): Version = JacksonModule.version
 
-  /**
-   * Whether this introspector supports type infers for polymorphic JSONTypeInfo
-   * for sealed traits/classes.
-   * @since 2.18
-   */
-  def supportInferenceOfJsonTypeInfo(): Boolean = true
-
   override def findPolymorphicTypeInfo(config: MapperConfig[_], ann: Annotated): JsonTypeInfo.Value = {
-    if (supportInferenceOfJsonTypeInfo()) {
+    if (supportInferenceOfJsonTypeInfo) {
       ann match {
         case ac: AnnotatedClass if isScala(ac) =>
           val t = _findAnnotation(ac, classOf[JsonTypeInfo])

--- a/src/main/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospectorModule.scala
+++ b/src/main/scala/com/github/pjfanning/jackson/reflect/ScalaReflectAnnotationIntrospectorModule.scala
@@ -1,7 +1,18 @@
 package com.github.pjfanning.jackson.reflect
 
 trait ScalaReflectAnnotationIntrospectorModule extends JacksonModule {
-  this += { _.appendAnnotationIntrospector(new ScalaReflectAnnotationIntrospector) }
+
+
+  /**
+   * Whether this introspector supports type infers for polymorphic JSONTypeInfo
+   * for sealed traits/classes.
+   * @since 2.18
+   */
+  def supportInferenceOfJsonTypeInfo(): Boolean = true
+
+  this += { _.appendAnnotationIntrospector(
+    new ScalaReflectAnnotationIntrospector(supportInferenceOfJsonTypeInfo()))
+  }
 }
 
 object ScalaReflectAnnotationIntrospectorModule extends ScalaReflectAnnotationIntrospectorModule

--- a/src/test/scala/com/github/pjfanning/jackson/reflect/UnannotatedClassesTest.scala
+++ b/src/test/scala/com/github/pjfanning/jackson/reflect/UnannotatedClassesTest.scala
@@ -1,0 +1,42 @@
+package com.github.pjfanning.jackson.reflect
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.github.pjfanning.jackson.reflect.unannotated._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class UnannotatedClassesTest extends AnyFlatSpec with Matchers {
+  "ScalaReflectAnnotationIntrospectorModule" should "serialize Car with unannotated.Color" in {
+    val mapper = JsonMapper.builder()
+      .addModule(DefaultScalaModule)
+      .addModule(ScalaReflectAnnotationIntrospectorModule)
+      .build()
+    val car = Car("Samand", Blue)
+    mapper.writeValueAsString(car) shouldEqual """{"make":"Samand","color":{"@type":"Blue$"}}"""
+  }
+
+  it should "deserialize Car with unannotated.Color" in {
+    // test no longer needs ScalaObjectDeserializerModule as it is now included in DefaultScalaModule since Jackson 2.16.0
+    val mapper = JsonMapper.builder()
+      .addModule(DefaultScalaModule)
+      .addModule(ScalaReflectAnnotationIntrospectorModule)
+      .build()
+    val car = Car("Samand", Red)
+    val json = mapper.writeValueAsString(car)
+    val car2 = mapper.readValue(json, classOf[Car])
+    car2.color shouldEqual car.color
+    car2.make shouldEqual car.make
+  }
+
+  it should "serialize unannotated.Country" in {
+    // we do need infer a JsonTypeInfo annotation for the unannotated.Country class
+    // because the class itself can be serialized in its own right
+    val mapper = JsonMapper.builder()
+      .addModule(DefaultScalaModule)
+      .addModule(ScalaReflectAnnotationIntrospectorModule)
+      .build()
+    val country = new Country("Andorra")
+    mapper.writeValueAsString(country) shouldEqual """{"name":"Andorra"}"""
+  }
+}

--- a/src/test/scala/com/github/pjfanning/jackson/reflect/unannotated/Country.scala
+++ b/src/test/scala/com/github/pjfanning/jackson/reflect/unannotated/Country.scala
@@ -1,0 +1,5 @@
+package com.github.pjfanning.jackson.reflect.unannotated
+
+class Country(val name: String)
+
+class CountryWithCapital(name: String, val capital: String) extends Country(name)


### PR DESCRIPTION
* relates to https://github.com/FasterXML/jackson-databind/issues/3596
* lots more to do
* need to fix broken tests
* need to change the ScalaReflectAnnotationIntrospectorModule so that is possible to define the JsonTypeInfo.Value instead of hardcoding it
* idea is that `@JsonTypeInfo` is used if set but that this module will infer an equivalent annotated value if not set (for Scala classes that have subtypes defined).